### PR TITLE
now using named URLs

### DIFF
--- a/hackday/teams/urls.py
+++ b/hackday/teams/urls.py
@@ -5,7 +5,8 @@ from teams.models import Team
 
 
 urlpatterns = patterns('teams.views',
-    (r'^/?$', ListView.as_view(model=Team)),
-    url(r'^create/?$', 'create'),
-    (r'^(?P<slug>[\w-]+)/*$', DetailView.as_view(model=Team)),
+    url(r'^/?$', ListView.as_view(model=Team), name='teams-list'),
+    url(r'^create/?$', 'create', name='teams-create'),
+    url(r'^(?P<slug>[\w-]+)/*$', DetailView.as_view(model=Team),
+        name='teams-detail'),
 )

--- a/hackday/teams/views.py
+++ b/hackday/teams/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from teams.forms import CreateTeamForm
@@ -17,6 +18,7 @@ def create(request):
         team.save()
         form.save_m2m()
 
-        return HttpResponseRedirect('/teams/' + team.slug)
+        return HttpResponseRedirect(reverse('teams-detail',
+            kwargs={'slug': team.slug}))
 
     return render(request, 'teams/team_form.html', {'form': form})

--- a/hackday/templates/teams/team_list.html
+++ b/hackday/templates/teams/team_list.html
@@ -9,7 +9,7 @@
 
     {% for team in team_list %}
 
-    <a href="/teams/{{ team.slug }}">{{ team.name }}</a>
+    <a href="{% url teams-detail slug=team.slug %}">{{ team.name }}</a>
     <br>
     captain: <span>{{ team.captain.get_full_name|default:team.captain.username }}</span>
 

--- a/hackday/urls.py
+++ b/hackday/urls.py
@@ -14,7 +14,7 @@ urlpatterns += patterns('',
     # url(r'^$', 'hackday.views.home', name='home'),
     # url(r'^hackday/', include('hackday.foo.urls')),
 
-    (r'^teams/?', include('teams.urls')),
+    (r'^teams/', include('teams.urls')),
 
     # Let the blog own the homepage?
     url(r'^/*$', 'blog.views.index', name='blog-home'),


### PR DESCRIPTION
this enables templates to do things like

```
...
href="{% url teams-detail slug=team.slug %}"
...
```

instead of

```
...
href="/teams/{{team.slug}}"
```

this removes the need for any hardcoding, and for the domain to change and
not mess up any routes
