### PR TITLE
Hide alternate email/phone

### DIFF
--- a/hackday/templates/users/profile.html
+++ b/hackday/templates/users/profile.html
@@ -8,9 +8,11 @@
     <p><strong>{{user_.first_name}} {{user_.last_name}}</strong></p>
     <p><strong>Email:</strong> {{user_.email}}</p>
     <p><strong>Alternate Email:</strong> {{user_profile.alternate_email}}</p>
-    <p><strong>Phone:</strong> {{user_profile.phone}}</p>
-    <p><strong>Created:</strong> {{user_profile.create_date}}</p>
-    <p><strong>Location:</strong> {{user_profile.location}}</p>
+	{% if user == user_ %}
+		<p><strong>Phone:</strong> {{user_profile.phone}}</p>
+		<p><strong>Created:</strong> {{user_profile.create_date}}</p>
+    {% endif %}
+	<p><strong>Location:</strong> {{user_profile.location}}</p>
     <p><strong>About Me:</strong></p>
     <p>{{user_profile.description}}</p>
 


### PR DESCRIPTION
Only show alternate email address and phone number when viewing your own profile
