### PR TITLE
Mail notification cleanup

### DIFF
--- a/hackday/blog/notifications.py
+++ b/hackday/blog/notifications.py
@@ -32,6 +32,7 @@ class BlogNotification(object):
                                          settings.DEFAULT_FROM_EMAIL,
                                          [settings.DEFAULT_FROM_EMAIL],
                                          recipients)
+        message.mixed_subtype = "related"
         try:
             body_html = self.render_template('blog/notification_email_html.html')
 


### PR DESCRIPTION
Current blog post emails display attached images at the bottom of the message as well as inline within the HTML.  Setting the message mixed_subtype to 'related' hides these duplicates.

Also seems to disable the plaintext mode, but I'll deal with that later.
